### PR TITLE
Replace CDN links with code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 Muilessium is a UI framework for static websites. 40+ components, 60+ utilities to make your code cleaner, LESS+RSCSS, fluid typography, keyboard and touchscreen support, understandable and well-organized code. The main purpose of its development is to create simple, but powerful framework for landings, personal websites, blogs etc.
 
 ## CDN
-https://unpkg.com/muilessium/dist/css/muilessium.min.css
-
-https://unpkg.com/muilessium/dist/js/muilessium.min.js
+```html
+<link rel='stylesheet' href='https://unpkg.com/muilessium/dist/css/muilessium.min.css'>
+<script src='https://unpkg.com/muilessium/dist/js/muilessium.min.js'></script>
+```
 
 ## NPM
 ```sh
@@ -36,6 +37,6 @@ npm run prod
 ## License
 MIT License
 
-Copyright (c) 2016-2018 Ivan Bogachev <sfi0zy@gmail.com>
+Copyright (c) 2016-2019 Ivan Bogachev <sfi0zy@gmail.com>
 
 

--- a/src/dss/index.handlebars
+++ b/src/dss/index.handlebars
@@ -139,13 +139,11 @@
                         </a>
                     </div>
                     <div class='_separate-1'>
-                        <h4 class='_bigger-0 _separate-1'>Unpkg</h4>
-                        <a href='https://unpkg.com/muilessium/dist/css/muilessium.min.css' class='mui-button'>CSS</a>
-                        <a href='https://unpkg.com/muilessium/dist/js/muilessium.min.js' class='mui-button'>JS</a>
-
-                        <h4 class='_bigger-0 _separate-1'>jsDelivr</h4>
-                        <a href='https://cdn.jsdelivr.net/npm/muilessium/dist/css/muilessium.min.css' class='mui-button'>CSS</a>
-                        <a href='https://cdn.jsdelivr.net/npm/muilessium/dist/js/muilessium.min.js' class='mui-button'>JS</a>
+                        <div class='code-example _separate-1 _smaller-1'>
+                            <pre class='source-code'>
+&lt;link rel='stylesheet' href='https://unpkg.com/muilessium/dist/css/muilessium.min.css'&gt;
+&lt;script src='https://unpkg.com/muilessium/dist/js/muilessium.min.js'&gt;&lt;/script&gt;</pre>
+                        </div>
                     </div>
                 </div>
                 <!-- /CDN -->


### PR DESCRIPTION
Fixes #55 

## Proposed Changes
  - Replace "CDN" buttons in the docs with code example
  - Replace links to the CDN in the readme with code example
