### PR TITLE
Fix Textarea.getValue behavior

### DIFF
--- a/src/muilessium-ui/components/textarea/script.js
+++ b/src/muilessium-ui/components/textarea/script.js
@@ -108,6 +108,10 @@ export default class Textarea extends FACTORY.BaseComponent {
 
 
     getValue() {
+        if (this.state.value !== this.domCache.textarea.value) {
+            this.changeEventHandler();
+        }
+
         return this.state.value;
     }
 }


### PR DESCRIPTION
Fixes #72 

## Proposed Changes
  - Force updating the value in the getValue method of the Textarea before returning.
