### PR TITLE
Fix grammar errors in docs

### DIFF
--- a/src/docs/muilessium/index.pug
+++ b/src/docs/muilessium/index.pug
@@ -94,22 +94,22 @@ html(lang='en')
                         ul.mui-list._separate-1
                             li.item
                                 a(href='#events-overview') EVENTS
-                                span &nbsp;- events observer
+                                span &nbsp;- Events observer
                             li.item
                                 a(href='#store-overview') STORE
-                                span &nbsp;- global store for data
+                                span &nbsp;- Global store for data
                             li.item
                                 a(href='#factory-overview') FACTORY
-                                span &nbsp;- the main factory of components
+                                span &nbsp;- The main factory of components
                             li.item
                                 a(href='#controls-overview') KEYBOARD, MOUSE, TOUCHPAD
-                                span &nbsp;- utilities for controls
+                                span &nbsp;- Utilities for controls
                             li.item
                                 a(href='#utils-overview') UTILS
-                                span &nbsp;- a number of other useful utilities
-                            li.item DATA_TYPES - data types
-                            li.item DEPENDENCIES - some ependencies for internal usage
-                            li.item POLYFILLS - some polyfills for internal usage
+                                span &nbsp;- A number of other useful utilities
+                            li.item DATA_TYPES - Data types
+                            li.item DEPENDENCIES - Some dependencies for internal usage
+                            li.item POLYFILLS - Some polyfills for internal usage
                         p.mui-p.-docs.-hint._separate-1.-blue-1-bg Run "console.log(Muilessium)" on this page to see the full structure of it.
                         p.mui-p A little example of the ajax request:
                         ._separate-1


### PR DESCRIPTION
Please see issue #68.

The document didn’t have many grammatical errors.

Fixes #

## Proposed Changes
  -
  -
  -
